### PR TITLE
Add support for Posts in Markdown format

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "node": "*"
   },
   "dependencies": {
-    "wordpress": "0.1.3"
+    "wordpress": "0.1.3",
+    "marked": "0.2.9"
   },
   "devDependencies": {
     "grunt": "0.3.x"


### PR DESCRIPTION
I was just doing this on my own fork but figured I'd submit a PR in case you're interested in this.

I've added support for posts to be in Markdown format as well (`.md` extension). For Markdown posts, I changed the "meta" block from `<script></script>` to `---` which matches Jekyll (HTML posts remain as is).

edit: If you are interested, I'll update the `README` to reflect these changes as well.
